### PR TITLE
UNSET `$HOME` before starting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ build: ## Build SAM app
 local: ## Run SAM local development server
 	cd duck-stac && \
 	sam local start-api \
+  		--env-vars lambda-env.json \
 		--region $(AWS_DEFAULT_REGION) \
 		--profile $(AWS_DEFAULT_PROFILE)
 

--- a/duck-stac/lambda-env.json
+++ b/duck-stac/lambda-env.json
@@ -1,0 +1,6 @@
+{
+  "DuckStacFunction": {
+    "HOME": "/tmp/",
+    "__comment": "This blocks SAM local from exporting invalid $HOME"
+  }
+}


### PR DESCRIPTION
`sam local` tries to use the `HOME` value from local machine in the running development server, which breaks duckdb's httpfs plugin.